### PR TITLE
fix: Allow AE (Reverse-Charge) to not have Umsatzsteuer of 7%

### DIFF
--- a/src/main/java/de/aronhomberg/Main.java
+++ b/src/main/java/de/aronhomberg/Main.java
@@ -77,12 +77,12 @@ public class Main {
             "DAY", "Tage (DAY)");
 
     private static final Map<String, String> TAX_TRANSLATIONS = Map.of(
-            "S", "19% (Normal, S)",
-            "AA", "7% (Ermäßigt, AA)",
+            TaxCategory.STANDARD, "19% (Normal, S)",
+            TaxCategory.LOWER_RATE, "7% (Ermäßigt, AA)",
             "E", "Befreit (E)",
-            "AE", "Steuerumkehr (AE)",
-            "K", "Innergemeinschaftliche Lieferung (K)",
-            "G", "0% (Nullsteuersatz, G)");
+            TaxCategory.REVERSE_CHARGE, "Steuerumkehr (AE)",
+            TaxCategory.INTRA_COMMUNITY, "Innergemeinschaftliche Lieferung (K)",
+            TaxCategory.FREE_EXPORT, "0% (Nullsteuersatz, G)");
 
     public static void main(String[] args) {
         // Set Look and Feel
@@ -743,6 +743,14 @@ public class Main {
     public static String getSummenUndSteuernField(String fieldName) {
         JTextField field = summenUndSteuernFieldsMap.get(fieldName);
         return field != null ? field.getText() : null;
+    }
+
+    /**
+     * Delegates the legacy invoice-level tax selection to the shared tax-category helper so the
+     * write path and embedded-read path apply the same fallback rule.
+     */
+    private static String dominantTaxCategory(List<InvoiceResponse.Invoice.InvoiceLine> invoiceLines) {
+        return TaxCategory.dominantCategory(invoiceLines);
     }
 
     private static JPanel createMeinUnternehmenTab() {
@@ -1643,15 +1651,6 @@ public class Main {
         monetarySummation.PayableAmount = parseGermanDouble.apply(getSummenUndSteuernField("Gesamtsumme brutto"));
         invoice.MonetarySummation = monetarySummation;
 
-        // Collect tax data
-        InvoiceResponse.Invoice.Tax tax = new InvoiceResponse.Invoice.Tax();
-        double steuer19 = parseGermanDouble.apply(getSummenUndSteuernField("Steuer 19%"));
-        double steuer7 = parseGermanDouble.apply(getSummenUndSteuernField("Steuer 7%"));
-        tax.TaxCategoryCode = steuer19 > 0 ? "S" : "AA";
-        tax.TaxPercentage = tax.TaxCategoryCode.equals("S") ? 19.0 : 7.0;
-        tax.TaxAmount = steuer19 + steuer7;
-        invoice.Tax = tax;
-
         // Collect position data
         List<Map<String, Object>> positions = getAllPositions();
         List<InvoiceResponse.Invoice.InvoiceLine> invoiceLines = new ArrayList<>();
@@ -1674,12 +1673,27 @@ public class Main {
             line.LineTotalAmount = gesamtpreisObj instanceof Number ? ((Number) gesamtpreisObj).doubleValue()
                     : parseGermanDouble.apply(String.valueOf(gesamtpreisObj));
 
-            line.TaxCategoryCode = String.valueOf(position.get("Steuerklasse"));
+            line.TaxCategoryCode = TaxCategory.normalize(String.valueOf(position.get("Steuerklasse")));
             line.Unit = String.valueOf(position.get("Einheit"));
-            line.TaxPercentage = line.TaxCategoryCode.equals("S") ? 19.0 : 7.0;
+            line.TaxPercentage = TaxCategory.toPercentage(line.TaxCategoryCode);
             invoiceLines.add(line);
         }
         invoice.InvoiceLines = invoiceLines;
+
+        // Collect tax data
+        InvoiceResponse.Invoice.Tax tax = new InvoiceResponse.Invoice.Tax();
+        double steuer19 = parseGermanDouble.apply(getSummenUndSteuernField("Steuer 19%"));
+        double steuer7 = parseGermanDouble.apply(getSummenUndSteuernField("Steuer 7%"));
+        // In EN 16931 / Peppol, AE is still a VAT category, not a different tax type.
+        // The difference is carried by TaxCategoryCode = AE plus a zero tax amount and a
+        // reverse-charge reason. See BR-AE-09 and BR-AE-10:
+        // https://docs.peppol.eu/poac/eu/pint-eu/trn-invoice/rule/BR-AE-09/
+        // https://docs.peppol.eu/poac/eu/pint-eu/trn-invoice/rule/BR-AE-10/
+        tax.TaxTypeCode = TaxCategory.VAT_TYPE;
+        tax.TaxAmount = steuer19 + steuer7;
+        tax.TaxCategoryCode = dominantTaxCategory(invoiceLines);
+        tax.TaxPercentage = TaxCategory.toPercentage(tax.TaxCategoryCode);
+        invoice.Tax = tax;
 
         return invoice;
     }

--- a/src/main/java/de/aronhomberg/Product.java
+++ b/src/main/java/de/aronhomberg/Product.java
@@ -1,19 +1,25 @@
 package de.aronhomberg;
 
-import org.mustangproject.ZUGFeRD.IZUGFeRDExportableProduct;
 import java.math.BigDecimal;
+import org.mustangproject.ZUGFeRD.IZUGFeRDExportableProduct;
 
 public class Product implements IZUGFeRDExportableProduct {
     private final String description;
     private final String name;
     private final String unit;
     private final BigDecimal VATPercent;
+    private final String taxCategoryCode;
 
     public Product(String description, String name, String unit, BigDecimal VATPercent) {
+        this(description, name, unit, VATPercent, TaxCategory.defaultForMissingSemanticCode(VATPercent));
+    }
+
+    public Product(String description, String name, String unit, BigDecimal VATPercent, String taxCategoryCode) {
         this.description = description;
         this.name = name;
         this.unit = unit;
         this.VATPercent = VATPercent;
+        this.taxCategoryCode = TaxCategory.normalize(taxCategoryCode);
     }
 
     @Override
@@ -34,5 +40,20 @@ public class Product implements IZUGFeRDExportableProduct {
     @Override
     public BigDecimal getVATPercent() {
         return VATPercent;
+    }
+
+    @Override
+    public boolean isReverseCharge() {
+        return TaxCategory.REVERSE_CHARGE.equals(taxCategoryCode);
+    }
+
+    @Override
+    public boolean isIntraCommunitySupply() {
+        return TaxCategory.INTRA_COMMUNITY.equals(taxCategoryCode);
+    }
+
+    @Override
+    public String getTaxCategoryCode() {
+        return taxCategoryCode;
     }
 }

--- a/src/main/java/de/aronhomberg/TaxCategory.java
+++ b/src/main/java/de/aronhomberg/TaxCategory.java
@@ -1,0 +1,107 @@
+package de.aronhomberg;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+final class TaxCategory {
+    // Peppol aligned tax category codes (UNCL 5305 subset). Official labels:
+    // S = "Standard rate", AA = "Lower rate", AE = "VAT Reverse Charge",
+    // K = "VAT exempt for EEA intra-community supply", Z = "Zero rated goods",
+    // G = "Free export item, tax not charged".
+    // Reference: https://docs.peppol.eu/poac/eu/pint-eu/trn-invoice/codelist/Aligned-TaxCategoryCodes/
+    static final String STANDARD = "S";
+    static final String LOWER_RATE = "AA";
+    static final String REVERSE_CHARGE = "AE";
+    static final String INTRA_COMMUNITY = "K";
+    static final String ZERO_RATED = "Z";
+    static final String FREE_EXPORT = "G";
+    static final String VAT_TYPE = "VAT";
+
+    private TaxCategory() {}
+
+    static String normalize(String taxCategoryCode) {
+        if (taxCategoryCode == null) {
+            return "";
+        }
+        String normalized = taxCategoryCode.trim().toUpperCase(Locale.ROOT);
+        // Why map Z -> G?
+        // The official Peppol list distinguishes Z ("Zero rated goods") from
+        // G ("Free export item, tax not charged"). We still collapse Z to G because the current
+        // desktop UI exposes only one generic 0% bucket and persists that bucket as G. This keeps
+        // imported embedded XML and older app data round-trippable through the existing UI model.
+        return normalized.equals(ZERO_RATED) ? FREE_EXPORT : normalized;
+    }
+
+    static String defaultForMissingSemanticCode(BigDecimal taxPercentage) {
+        // Only used when the caller gave us a percentage but no semantic category code.
+        // The current app model has a single generic 0% bucket and persists it as G, so this
+        // fallback preserves existing app behavior instead of guessing between G, Z, AE or K.
+        return fromPercentage(taxPercentage);
+    }
+
+    static String fromPercentage(BigDecimal taxPercentage) {
+        BigDecimal percentage = taxPercentage == null ? BigDecimal.ZERO : taxPercentage.stripTrailingZeros();
+        if (percentage.compareTo(BigDecimal.ZERO) == 0) {
+            // A numeric 0% rate alone is not enough to distinguish AE, K, Z and G.
+            // If only the percentage is known, we fall back to the app's generic 0% bucket.
+            return FREE_EXPORT;
+        }
+        if (percentage.compareTo(new BigDecimal("7")) == 0) {
+            return LOWER_RATE;
+        }
+        return STANDARD;
+    }
+
+    static String fromPercentage(double taxPercentage) {
+        return fromPercentage(BigDecimal.valueOf(taxPercentage));
+    }
+
+    static double toPercentage(String taxCategoryCode) {
+        // Reverse charge remains under the VAT tax scheme, but its amount/rate contribution is 0.
+        // Peppol BR-AE-09 says the VAT category tax amount for reverse charge "shall be 0 (zero)":
+        // https://docs.peppol.eu/poac/eu/pint-eu/trn-invoice/rule/BR-AE-09/
+        return switch (normalize(taxCategoryCode)) {
+            case STANDARD -> 19.0;
+            case LOWER_RATE -> 7.0;
+            default -> 0.0;
+        };
+    }
+
+    /**
+     * Chooses a single invoice-level tax category from the line-level categories.
+     *
+     * The app's current invoice model stores one top-level {@code invoice.Tax} object even though
+     * real EN 16931 / Peppol invoices can contain multiple VAT breakdown rows. To keep that legacy
+     * model internally consistent, we choose the tax category with the largest aggregated net line
+     * basis and use it as the representative top-level category.
+     *
+     * This is an application fallback for the simplified UI/data model, not an EN 16931 rule.
+     * Line-level categories remain the authoritative source when multiple tax categories occur.
+     */
+    static String dominantCategory(List<InvoiceResponse.Invoice.InvoiceLine> invoiceLines) {
+        Map<String, BigDecimal> basisByCategory = new LinkedHashMap<>();
+        for (InvoiceResponse.Invoice.InvoiceLine line : invoiceLines) {
+            if (line == null) {
+                continue;
+            }
+            String taxCategoryCode = normalize(line.TaxCategoryCode);
+            if (taxCategoryCode.isEmpty()) {
+                taxCategoryCode = fromPercentage(line.TaxPercentage);
+            }
+            basisByCategory.merge(taxCategoryCode, BigDecimal.valueOf(line.LineTotalAmount), BigDecimal::add);
+        }
+
+        BigDecimal dominantBasis = BigDecimal.ZERO;
+        String dominantCategory = FREE_EXPORT;
+        for (var entry : basisByCategory.entrySet()) {
+            if (entry.getValue().compareTo(dominantBasis) > 0) {
+                dominantBasis = entry.getValue();
+                dominantCategory = entry.getKey();
+            }
+        }
+        return dominantCategory;
+    }
+}

--- a/src/main/java/de/aronhomberg/ZUGFeRDInvoiceWriter.java
+++ b/src/main/java/de/aronhomberg/ZUGFeRDInvoiceWriter.java
@@ -211,7 +211,12 @@ public class ZUGFeRDInvoiceWriter implements IExportableTransaction {
             items[i] = new Item(
                     BigDecimal.valueOf(line.UnitPrice),
                     BigDecimal.valueOf(line.Quantity),
-                    new Product(line.ProductName, line.ProductName, unit, BigDecimal.valueOf(line.TaxPercentage))
+                    new Product(
+                            line.ProductName,
+                            line.ProductName,
+                            unit,
+                            BigDecimal.valueOf(line.TaxPercentage),
+                            line.TaxCategoryCode)
             );
         }
         return items;

--- a/src/main/java/de/aronhomberg/ZugferdEmbeddedReader.java
+++ b/src/main/java/de/aronhomberg/ZugferdEmbeddedReader.java
@@ -13,7 +13,6 @@ import java.time.ZoneId;
 import java.util.*;
 
 public final class ZugferdEmbeddedReader {
-
     private ZugferdEmbeddedReader() {}
 
     public static Optional<InvoiceResponse.Invoice> tryParse(String pdfPath) {
@@ -62,7 +61,10 @@ public final class ZugferdEmbeddedReader {
 
                 BigDecimal vat = it.getProduct() != null ? bd(it.getProduct().getVATPercent()) : BigDecimal.ZERO;
                 l.TaxPercentage = vat.doubleValue();
-                l.TaxCategoryCode = taxCategoryFromPercent(vat);
+                String taxCategoryCode = it.getProduct() != null
+                        ? TaxCategory.normalize(it.getProduct().getTaxCategoryCode())
+                        : "";
+                l.TaxCategoryCode = taxCategoryCode.isEmpty() ? TaxCategory.fromPercentage(vat) : taxCategoryCode;
 
                 lines.add(l);
             }
@@ -102,20 +104,12 @@ public final class ZugferdEmbeddedReader {
 
             BigDecimal taxAmount = grandTotal.subtract(taxExclusive).max(BigDecimal.ZERO);
 
-            // Pick "dominant" VAT rate/category (highest basis)
-            BigDecimal dominantRate = BigDecimal.ZERO;
-            BigDecimal dominantBasis = BigDecimal.ZERO;
-            for (var entry : vatBasisByRate.entrySet()) {
-                if (entry.getValue().compareTo(dominantBasis) > 0) {
-                    dominantBasis = entry.getValue();
-                    dominantRate = entry.getKey();
-                }
-            }
+            String dominantCategory = TaxCategory.dominantCategory(lines);
 
             out.Tax = new InvoiceResponse.Invoice.Tax();
-            out.Tax.TaxTypeCode = "VAT";
-            out.Tax.TaxCategoryCode = taxCategoryFromPercent(dominantRate);
-            out.Tax.TaxPercentage = dominantRate.doubleValue();
+            out.Tax.TaxTypeCode = TaxCategory.VAT_TYPE;
+            out.Tax.TaxCategoryCode = dominantCategory;
+            out.Tax.TaxPercentage = TaxCategory.toPercentage(dominantCategory);
             out.Tax.TaxAmount = taxAmount.setScale(2, RoundingMode.HALF_UP).doubleValue();
 
             return Optional.of(out);
@@ -152,14 +146,6 @@ public final class ZugferdEmbeddedReader {
         String t = s.trim();
         return t.isEmpty() ? fallback : t;
     }
-
-    private static String taxCategoryFromPercent(BigDecimal percent) {
-        BigDecimal p = percent == null ? BigDecimal.ZERO : percent.stripTrailingZeros();
-        if (p.compareTo(BigDecimal.ZERO) == 0) return "G";
-        if (p.compareTo(new BigDecimal("7")) == 0) return "AA";
-        return "S";
-    }
-
     private static <T> T safe(SupplierX<T> s) {
         try { return s.get(); } catch (Exception e) { return null; }
     }

--- a/src/test/java/de/aronhomberg/TaxCategoryTest.java
+++ b/src/test/java/de/aronhomberg/TaxCategoryTest.java
@@ -1,0 +1,35 @@
+package de.aronhomberg;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TaxCategoryTest {
+
+    @Test
+    void normalizesZeroRatedGoodsToTheAppsGenericZeroPercentBucket() {
+        assertEquals("G", TaxCategory.normalize("Z"));
+    }
+
+    @Test
+    void picksDominantCategoryByAggregatedNetBasis() {
+        InvoiceResponse.Invoice.InvoiceLine firstReverseChargeLine = new InvoiceResponse.Invoice.InvoiceLine();
+        firstReverseChargeLine.TaxCategoryCode = "AE";
+        firstReverseChargeLine.LineTotalAmount = 60.0;
+
+        InvoiceResponse.Invoice.InvoiceLine secondReverseChargeLine = new InvoiceResponse.Invoice.InvoiceLine();
+        secondReverseChargeLine.TaxCategoryCode = "AE";
+        secondReverseChargeLine.LineTotalAmount = 50.0;
+
+        InvoiceResponse.Invoice.InvoiceLine standardRateLine = new InvoiceResponse.Invoice.InvoiceLine();
+        standardRateLine.TaxCategoryCode = "S";
+        standardRateLine.LineTotalAmount = 100.0;
+
+        assertEquals("AE", TaxCategory.dominantCategory(List.of(
+                firstReverseChargeLine,
+                secondReverseChargeLine,
+                standardRateLine)));
+    }
+}

--- a/src/test/java/de/aronhomberg/ZUGFeRDInvoiceWriterTest.java
+++ b/src/test/java/de/aronhomberg/ZUGFeRDInvoiceWriterTest.java
@@ -1,0 +1,33 @@
+package de.aronhomberg;
+
+import org.junit.jupiter.api.Test;
+import org.mustangproject.ZUGFeRD.IZUGFeRDExportableItem;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZUGFeRDInvoiceWriterTest {
+
+    @Test
+    void preservesReverseChargeTaxCategoryOnExportedItems() {
+        InvoiceResponse.Invoice invoice = new InvoiceResponse.Invoice();
+        InvoiceResponse.Invoice.InvoiceLine line = new InvoiceResponse.Invoice.InvoiceLine();
+        line.ProductName = "Beratung";
+        line.Quantity = 1.0;
+        line.UnitPrice = 100.0;
+        line.TaxCategoryCode = "AE";
+        line.TaxPercentage = 0.0;
+        line.Unit = "HUR";
+        invoice.InvoiceLines = List.of(line);
+
+        ZUGFeRDInvoiceWriter writer = new ZUGFeRDInvoiceWriter(invoice, "sample.pdf");
+        IZUGFeRDExportableItem[] items = writer.getZFItems();
+
+        assertEquals(1, items.length);
+        assertEquals("AE", items[0].getProduct().getTaxCategoryCode());
+        assertTrue(items[0].getProduct().isReverseCharge());
+        assertEquals(0.0, items[0].getProduct().getVATPercent().doubleValue());
+    }
+}


### PR DESCRIPTION
Also refactor so that `TaxCode` logic is in one place.

Disclaimer, I used codex to generate most of the code. All lines a human (me) read, however.